### PR TITLE
Make the clamd location and name configurable

### DIFF
--- a/attributes/clamd.rb
+++ b/attributes/clamd.rb
@@ -25,11 +25,14 @@ default['clamav']['clamd']['enabled'] = false
 case node['platform_family']
 when 'rhel'
   default['clamav']['clamd']['service'] = 'clamd'
+  default['clamav']['clamd']['conf_dir'] = '/etc'
 when 'debian'
   default['clamav']['clamd']['service'] = 'clamav-daemon'
+  default['clamav']['clamd']['conf_dir'] = '/etc/clamav'
 end
 
 # Options - clamd.conf
+default['clamav']['clamd']['config_name'] = 'clamd.conf'
 default['clamav']['clamd']['log_file'] = '/var/log/clamav/clamd.log'
 default['clamav']['clamd']['logrotate_frequency'] = 'daily'
 default['clamav']['clamd']['logrotate_rotations'] = 7

--- a/recipes/clamd.rb
+++ b/recipes/clamd.rb
@@ -21,7 +21,7 @@
 include_recipe "#{cookbook_name}::services"
 
 supp_groups = node['clamav']['allow_supplementary_groups']
-template "#{node['clamav']['conf_dir']}/clamd.conf" do
+template "#{node['clamav']['clamd']['conf_dir']}/#{node['clamav']['clamd']['config_name']}" do
   owner node['clamav']['user']
   group node['clamav']['group']
   source 'clamd.conf.erb'


### PR DESCRIPTION
We're running into errors that our clamd config is in the wrong place, likely due to some arbitrary change by clamav

Suffice to say, we need this to run, so this gives us the option to set the config location.