### PR TITLE
Use the configured clamd path for nightly scans

### DIFF
--- a/recipes/clamav_scan.rb
+++ b/recipes/clamav_scan.rb
@@ -18,11 +18,14 @@
 # limitations under the License.
 #
 
-cookbook_file node['clamav']['scan']['script']['path'] do
-  source 'clamav-scan.sh'
+template node['clamav']['scan']['script']['path'] do
+  source 'clamav-scan.sh.erb'
   owner node['clamav']['user']
   group node['clamav']['group']
   mode '0555'
+  variables(
+    config_path: "#{node['clamav']['clamd']['conf_dir']}/#{node['clamav']['clamd']['config_name']}"
+  )
   only_if { node['clamav']['scan']['script']['enable'] }
 end
 

--- a/templates/default/clamav-scan.sh.erb
+++ b/templates/default/clamav-scan.sh.erb
@@ -1,11 +1,12 @@
 #!/bin/sh
 # Inspired by <http://guylabs.ch/2013/09/18/install-clamav-antivirus-in-ubuntu-server-and-client/>
- 
+
 NOW=`/bin/date '+%Y%m%dT%H%M%S'` # ISO 8601 format
 LOGFILE="/var/log/clamav/clamav-scan.log.$NOW"
 HOST=`/bin/hostname`
+CONFIGFILE=<%= @config_path %>
 
-CLAMDSCAN="/usr/bin/clamdscan --fdpass --log=$LOGFILE --multiscan"
+CLAMDSCAN="/usr/bin/clamdscan --fdpass --log=$LOGFILE --config-file=$CONFIGFILE --multiscan"
 
 # emtpy the old scanlog and do a virus scan
 rm -f $LOGFILE
@@ -23,7 +24,7 @@ fi
 echo "============" >> $LOGFILE
 echo "Scan Ended" >> $LOGFILE
 date >> $LOGFILE
- 
+
 ### Send the email
 if grep -rl 'Infected files: 0' $LOGFILE
     then


### PR DESCRIPTION
https://github.com/DocuTAP/clamav-chef/pull/1 got us past a point where we were failing setup because the initial clamav run was looking for a file in the wrong place (or, rather, because we were writing that file to the wrong place).  We're now setting up new servers without issue, but nightly scans are looking for a configuration in a different place from the initial setup.  Rather than try to write the same file to two places, I'd prefer to just make explicit reference to the right path in the actual command invocation, so that if the defaults ever change again we should still be alright.